### PR TITLE
add support for differeing line endings

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -2,6 +2,7 @@
 
 var utils = require('./utils');
 var EOL = require('os').EOL; // OS-dependent End-of-Line;
+var EOLRegExp = /\r\n|\r|\n/gm;
 
 function parser(code, options, config) {
 
@@ -44,10 +45,18 @@ function parser(code, options, config) {
                     s += '/';
                     continue;
                 }
-                var lb = code.indexOf(EOL, idx + 2);
-                if (lb < 0) {
+                
+                //var lb = code.indexOf(EOL, idx + 2);
+                EOLRegExp.lastIndex = idx + 2;
+                var lbFind = EOLRegExp.exec(code);
+                
+                if (!lbFind) {
                     break;
                 }
+                
+                var lb = lbFind.index;
+                EOL = lbFind[0];
+                
                 if (emptyLine) {
                     emptyLetters = '';
                     if (optSpace) {
@@ -90,7 +99,12 @@ function parser(code, options, config) {
                             s += EOL;
                         }
                     }
-                    var lb = code.indexOf(EOL, idx + 1);
+                    //var lb = code.indexOf(EOL, idx + 1);
+                    EOLRegExp.lastIndex = idx + 1;
+                    var lbFind = EOLRegExp.exec(code);
+                    var lb = lbFind ? lbFind.index : -1;
+                    if(lbFind) EOL = lbFind[0];
+                    
                     if (lb > idx) {
                         var gapIdx = lb - 1;
                         while ((code[gapIdx] === ' ' || code[gapIdx] === '\t') && --gapIdx > idx);
@@ -134,7 +148,12 @@ function parser(code, options, config) {
                     s += EOL;
                 }
             }
-            var lb = code.indexOf(EOL, idx + 1);
+            //var lb = code.indexOf(EOL, idx + 1);
+            EOLRegExp.lastIndex = idx + 1;
+            var lbFind = EOLRegExp.exec(code);
+            var lb = lbFind ? lbFind.index : -1;
+            if(lbFind) EOL = lbFind[0];
+            
             if (lb > idx) {
                 var gapIdx = lb - 1;
                 while ((code[gapIdx] === ' ' || code[gapIdx] === '\t') && --gapIdx > idx);
@@ -214,7 +233,11 @@ function parser(code, options, config) {
             var startIdx, endIdx, i;
             do {
                 startIdx = idx + 1;
-                endIdx = code.indexOf(EOL, startIdx);
+                //endIdx = code.indexOf(EOL, startIdx);
+                EOLRegExp.lastIndex = startIdx;
+                var lbFind = EOLRegExp.exec(code);
+                endIdx = lbFind ? lbFind.index : -1;
+                if(lbFind) EOL = lbFind[0];
                 i = startIdx;
                 while ((code[i] === ' ' || code[i] === '\t') && ++i < endIdx);
                 if (i === endIdx) {

--- a/test/singleSpec.js
+++ b/test/singleSpec.js
@@ -138,6 +138,15 @@ describe("Single:", function () {
         });
     });
 
+    describe("with differing line endings", function () {
+        ['\r\n','\r','\n'].forEach(function(LB){
+            it("must be removed and preserve code", function () {
+                expect(decomment("//text" + LB + LB + "end", {trim: true})).toBe("end");
+                expect(decomment("//text" + LB + "\t" + LB + "end", {trim: true})).toBe("end");
+            });
+        });
+    });
+
     describe("inside regEx", function () {
         it("must be ignored", function () {
             expect(decomment("/[a-b//]text/")).toBe("/[a-b//]text/");


### PR DESCRIPTION
Use regex instead of os.EOL to support mixed line endings.

See #4 