### PR TITLE
Support custom safe reg exp

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,17 @@ this method will remove `//` and `/**/` comments according to the `options` (see
 * `true` - keep multi-line comments that start with `/*!`
 * `RegExp` - provide a matcher for custom safe comment format
 
-Example:
+Basic Example:
 
 ```js
 var decomment = require('decomment');
 var code = "/*! special */ var a; /* normal */";
 decomment(code); //=> var a;
 decomment(code, {safe: true}); //=> /*! special */ var a;
+```
 
-//RegExp Example
+RegExp Example:
+```js
 var code = "/** jsDoc style comment */  var a; /* normal */";
 decomment(code); //=> var a;
 decomment(code, {safe: /^\/\*\* /}); //=> /** jsDoc style comment */ var a;

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ var decomment = require('decomment');
 var code = "/*! special */ var a; /* normal */";
 decomment(code); //=> var a;
 decomment(code, {safe: true}); //=> /*! special */ var a;
+
+//RegExp Example
+var code = "/** jsDoc style comment */  var a; /* normal */";
+decomment(code); //=> var a;
 decomment(code, {safe: /^\/\*\* /}); //=> /** jsDoc style comment */ var a;
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ about regular expressions.
 If [esprima] fails to validate the code, it will throw a parsing error. When successful,
 this method will remove `//` and `/**/` comments according to the `options` (see below).
 
-##### options.safe ⇒ Boolean
+##### options.safe ⇒ Boolean | RegExp
 
 * `false (default)` - remove all multi-line comments
 * `true` - keep multi-line comments that start with `/*!`
+* `RegExp` - provide a matcher for custom safe comment format (example to keep JSDoc use: `/^\/\*\* /`)
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ this method will remove `//` and `/**/` comments according to the `options` (see
 
 * `false (default)` - remove all multi-line comments
 * `true` - keep multi-line comments that start with `/*!`
-* `RegExp` - provide a matcher for custom safe comment format (example to keep JSDoc use: `/^\/\*\* /`)
+* `RegExp` - provide a matcher for custom safe comment format
 
 Example:
 
@@ -80,6 +80,7 @@ var decomment = require('decomment');
 var code = "/*! special */ var a; /* normal */";
 decomment(code); //=> var a;
 decomment(code, {safe: true}); //=> /*! special */ var a;
+decomment(code, {safe: /^\/\*\* /}); //=> /** jsDoc style comment */ var a;
 ```
 
 NOTE: This option has no effect when processing HTML.

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -22,8 +22,9 @@ function parser(code, options, config) {
         optTrim = options && options.trim, // 'trim' option;
         EOL = utils.getEOL(code, options && options.platform),
         isHtml, // set when the input is recognized as HTML;
-        regEx; // regular expression details;
-
+        regEx, // regular expression details;
+        safeMatch = optSafe === true ? /^\/\*\!/ : optSafe;
+        
     if (!len) {
         return code;
     }
@@ -67,7 +68,7 @@ function parser(code, options, config) {
                     continue;
                 }
                 var end = code.indexOf('*/', idx + 2);
-                var keep = optSafe && idx < len - 2 && code[idx + 2] === '!';
+                var keep = optSafe && idx < len - 2 && safeMatch.test(code.substr(idx));
                 if (keep) {
                     if (end >= 0) {
                         s += code.substr(idx, end - idx + 2);

--- a/test/multiSpec.js
+++ b/test/multiSpec.js
@@ -171,6 +171,24 @@ describe("Multi:", function () {
         });
     });
 
+    describe("with custom safe options", function () {
+        it("must become empty when safe=false", function () {
+            expect(decomment("/** blah haha */")).toBe("");
+        });
+
+        it("must become empty when safe=false", function () {
+            expect(decomment("/*** blah haha */")).toBe("");
+        });
+
+        it("must keep comments when safe is set to matching regex", function () {
+            expect(decomment("/** test this */", {safe: /^\/\*\* /})).toBe("/** test this */");
+        });
+
+        it("must become empty when regex does not match", function () {
+            expect(decomment("/*** test this */", {safe: /^\/\*\* /})).toBe("");
+        });
+    });
+
     describe("combination of options", function () {
         it("must process correctly", function () {
             expect(decomment("/*!special*/" + LB + LB + "code" + LB + "/*normal*/" + LB + LB + "hello" + LB, {


### PR DESCRIPTION
Add ability to use custom patterns for the safe comment.

One example for when this might be useful (my use case) would be to preserve only JSDoc style comments. It could also be useful for anyone that wants to use something other than /*!  to preserve comments.

This is a non-breaking change as safe still has the same default value and can support a boolean, but if you specify a regex or string it will use the provided value as a matcher for preserved comments.

**Usage Example:**

```
decomment('/** JSDoc style comment */ here is some stuff', {safe: /^\/\*\* /});
```