### PR TITLE
Fix a bug copied from SO

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You can isolate all `url(*)` blocks by using:
 you can use the following:
 
 ```js
-{ignore: /\/\*\*\s*\n([^\*]*(\*[^\/])?)*\*\//g}
+{ignore: /\/\*\*\s*\n([^\*]|(\*(?!\/)))*\*\//g}
 ``` 
 
 ##### options.space ⇒ Boolean


### PR DESCRIPTION
The regex used for ignoring jsDoc blocks was copied from [a StackOverflow answer](https://stackoverflow.com/questions/35905181/regex-for-jsdoc-comments/35923766#35923766). Now we found that it contained a bug preventing it from working correctly on certain (uncommon) types of comments. This is a corrected version that should work properly.